### PR TITLE
Fix incorrect form recovery after battle ends

### DIFF
--- a/fabric/src/main/java/com/cobblemon/yajatkaul/mega_showdown/event/CobbleEvents.java
+++ b/fabric/src/main/java/com/cobblemon/yajatkaul/mega_showdown/event/CobbleEvents.java
@@ -39,7 +39,6 @@ public class CobbleEvents {
         DynamaxEventLogic.register();
         UltraEventLogic.register();
 
-        CobblemonEvents.BATTLE_VICTORY.subscribe(Priority.NORMAL, RevertEvents::getBattleEndInfo);
-        CobblemonEvents.BATTLE_FLED.subscribe(Priority.NORMAL, RevertEvents::deVolveFlee);
+        CobblemonEvents.BATTLE_STARTED_POST.subscribe(Priority.NORMAL, RevertEvents::hookBattleEnded);
     }
 }

--- a/fabric/src/main/java/com/cobblemon/yajatkaul/mega_showdown/event/cobbleEvents/RevertEvents.java
+++ b/fabric/src/main/java/com/cobblemon/yajatkaul/mega_showdown/event/cobbleEvents/RevertEvents.java
@@ -2,10 +2,7 @@ package com.cobblemon.yajatkaul.mega_showdown.event.cobbleEvents;
 
 import com.cobblemon.mod.common.Cobblemon;
 import com.cobblemon.mod.common.api.battles.model.actor.BattleActor;
-import com.cobblemon.mod.common.api.events.battles.BattleFaintedEvent;
-import com.cobblemon.mod.common.api.events.battles.BattleFledEvent;
-import com.cobblemon.mod.common.api.events.battles.BattleStartedPreEvent;
-import com.cobblemon.mod.common.api.events.battles.BattleVictoryEvent;
+import com.cobblemon.mod.common.api.events.battles.*;
 import com.cobblemon.mod.common.api.moves.Move;
 import com.cobblemon.mod.common.api.moves.Moves;
 import com.cobblemon.mod.common.api.pokemon.feature.FlagSpeciesFeature;
@@ -136,16 +133,21 @@ public class RevertEvents {
         return false; // Not found
     }
 
-    public static Unit getBattleEndInfo(BattleVictoryEvent battleVictoryEvent) {
-        battleVictoryEvent.getBattle().getPlayers().forEach(serverPlayer -> {
-            PlayerPartyStore playerPartyStore = Cobblemon.INSTANCE.getStorage().getParty(serverPlayer);
-            for (Pokemon pokemon : playerPartyStore) {
-                EventUtils.revertFormesEnd(pokemon);
+    public static Unit hookBattleEnded(BattleStartedPostEvent event) {
+        event.getBattle().getOnEndHandlers().add(battle -> {
+            battle.getPlayers().forEach(serverPlayer -> {
+                PlayerPartyStore playerPartyStore = Cobblemon.INSTANCE.getStorage().getParty(serverPlayer);
+                for (Pokemon pokemon : playerPartyStore) {
 
-                if (pokemon.getEntity() != null) {
-                    pokemon.getEntity().removeStatusEffect(StatusEffects.GLOWING);
+                    EventUtils.revertFormesEnd(pokemon);
+
+                    if (pokemon.getEntity() != null) {
+                        pokemon.getEntity().removeStatusEffect(StatusEffects.GLOWING);
+                    }
                 }
-            }
+            });
+
+            return Unit.INSTANCE;
         });
 
         return Unit.INSTANCE;
@@ -165,21 +167,6 @@ public class RevertEvents {
         if (isMega) {
             MegaLogic.Devolve(pokemon, true);
         }
-
-        return Unit.INSTANCE;
-    }
-
-    public static Unit deVolveFlee(BattleFledEvent battleFledEvent) {
-        battleFledEvent.getBattle().getPlayers().forEach(serverPlayer -> {
-            PlayerPartyStore playerPartyStore = Cobblemon.INSTANCE.getStorage().getParty(serverPlayer);
-            for (Pokemon pokemon : playerPartyStore) {
-                EventUtils.revertFormesEnd(pokemon);
-
-                if (pokemon.getEntity() != null) {
-                    pokemon.getEntity().removeStatusEffect(StatusEffects.GLOWING);
-                }
-            }
-        });
 
         return Unit.INSTANCE;
     }

--- a/neoforge/src/main/java/com/cobblemon/yajatkaul/mega_showdown/event/CobbleEvents.java
+++ b/neoforge/src/main/java/com/cobblemon/yajatkaul/mega_showdown/event/CobbleEvents.java
@@ -40,7 +40,6 @@ public class CobbleEvents {
         NeoForge.EVENT_BUS.register(new DynamaxEventListener());
         NeoForge.EVENT_BUS.register(new UltraEventListener());
 
-        CobblemonEvents.BATTLE_VICTORY.subscribe(Priority.NORMAL, RevertEvents::battleEnded);
-        CobblemonEvents.BATTLE_FLED.subscribe(Priority.NORMAL, RevertEvents::deVolveFlee);
+        CobblemonEvents.BATTLE_STARTED_POST.subscribe(Priority.NORMAL, RevertEvents::hookBattleEnded);
     }
 }

--- a/neoforge/src/main/java/com/cobblemon/yajatkaul/mega_showdown/event/cobbleEvents/RevertEvents.java
+++ b/neoforge/src/main/java/com/cobblemon/yajatkaul/mega_showdown/event/cobbleEvents/RevertEvents.java
@@ -2,16 +2,12 @@ package com.cobblemon.yajatkaul.mega_showdown.event.cobbleEvents;
 
 import com.cobblemon.mod.common.Cobblemon;
 import com.cobblemon.mod.common.api.battles.model.actor.BattleActor;
-import com.cobblemon.mod.common.api.events.battles.BattleFaintedEvent;
-import com.cobblemon.mod.common.api.events.battles.BattleFledEvent;
-import com.cobblemon.mod.common.api.events.battles.BattleStartedPreEvent;
-import com.cobblemon.mod.common.api.events.battles.BattleVictoryEvent;
+import com.cobblemon.mod.common.api.events.battles.*;
 import com.cobblemon.mod.common.api.moves.Move;
 import com.cobblemon.mod.common.api.moves.Moves;
 import com.cobblemon.mod.common.api.pokemon.feature.FlagSpeciesFeature;
 import com.cobblemon.mod.common.api.storage.party.PlayerPartyStore;
 import com.cobblemon.mod.common.api.storage.player.GeneralPlayerData;
-import com.cobblemon.mod.common.battles.ActiveBattlePokemon;
 import com.cobblemon.mod.common.battles.pokemon.BattlePokemon;
 import com.cobblemon.mod.common.pokemon.Pokemon;
 import com.cobblemon.yajatkaul.mega_showdown.MegaShowdown;
@@ -36,17 +32,21 @@ import top.theillusivec4.curios.api.CuriosApi;
 import top.theillusivec4.curios.api.SlotResult;
 
 public class RevertEvents {
-    public static Unit battleEnded(BattleVictoryEvent battleVictoryEvent) {
-        battleVictoryEvent.getBattle().getPlayers().forEach(serverPlayer -> {
-            PlayerPartyStore playerPartyStore = Cobblemon.INSTANCE.getStorage().getParty(serverPlayer);
-            for (Pokemon pokemon : playerPartyStore) {
+    public static Unit hookBattleEnded(BattleStartedPostEvent event) {
+        event.getBattle().getOnEndHandlers().add(battle -> {
+            battle.getPlayers().forEach(serverPlayer -> {
+                PlayerPartyStore playerPartyStore = Cobblemon.INSTANCE.getStorage().getParty(serverPlayer);
+                for (Pokemon pokemon : playerPartyStore) {
 
-                EventUtils.revertFormesEnd(pokemon);
+                    EventUtils.revertFormesEnd(pokemon);
 
-                if (pokemon.getEntity() != null) {
-                    pokemon.getEntity().removeEffect(MobEffects.GLOWING);
+                    if (pokemon.getEntity() != null) {
+                        pokemon.getEntity().removeEffect(MobEffects.GLOWING);
+                    }
                 }
-            }
+            });
+
+            return Unit.INSTANCE;
         });
 
         return Unit.INSTANCE;
@@ -66,21 +66,6 @@ public class RevertEvents {
         if (isMega) {
             MegaLogic.Devolve(pokemon, true);
         }
-
-        return Unit.INSTANCE;
-    }
-
-    public static Unit deVolveFlee(BattleFledEvent battleFledEvent) {
-        battleFledEvent.getBattle().getPlayers().forEach(serverPlayer -> {
-            PlayerPartyStore playerPartyStore = Cobblemon.INSTANCE.getStorage().getParty(serverPlayer);
-            for (Pokemon pokemon : playerPartyStore) {
-                EventUtils.revertFormesEnd(pokemon);
-
-                if (pokemon.getEntity() != null) {
-                    pokemon.getEntity().removeEffect(MobEffects.GLOWING);
-                }
-            }
-        });
 
         return Unit.INSTANCE;
     }


### PR DESCRIPTION
  When the battle ends, if the player logs off directly, neither the BattleVictoryEvent nor the BattleFleeEvent will be triggered, preventing the Pokémon's form from being properly restored.
  As a result, when the player logs back in, the Pokémon will retain its battle form. This submission should fix the issue.