### PR TITLE
Simple Battle HUD Fixes

### DIFF
--- a/common/src/main/java/com/github/yajatkaul/mega_showdown/api/lilycobble/networking/battle/BattlePokemonState.java
+++ b/common/src/main/java/com/github/yajatkaul/mega_showdown/api/lilycobble/networking/battle/BattlePokemonState.java
@@ -4,8 +4,10 @@ import com.cobblemon.mod.common.api.battles.interpreter.BattleContext;
 import com.cobblemon.mod.common.api.moves.Move;
 import com.cobblemon.mod.common.api.pokemon.PokemonPropertyExtractor;
 import com.cobblemon.mod.common.api.pokemon.status.Status;
+import com.cobblemon.mod.common.api.types.ElementalTypes;
 import com.cobblemon.mod.common.battles.pokemon.BattlePokemon;
 import com.cobblemon.mod.common.pokemon.status.PersistentStatusContainer;
+import com.github.yajatkaul.mega_showdown.MegaShowdown;
 import com.github.yajatkaul.mega_showdown.api.lilycobble.pokemon.PokemonPropertiesSupplier;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
@@ -77,6 +79,7 @@ public record BattlePokemonState(
         Map<String, Integer> statChanges = new HashMap<>();
         Collection<BattleContext> boosts = pokemon.getContextManager().get(BattleContext.Type.BOOST);
         Collection<BattleContext> unboosts = pokemon.getContextManager().get(BattleContext.Type.UNBOOST);
+        Collection<BattleContext> volatiles = pokemon.getContextManager().get(BattleContext.Type.VOLATILE);
 
         if (boosts != null) {
             for (BattleContext boost : boosts) {
@@ -87,6 +90,19 @@ public record BattlePokemonState(
         if (unboosts != null) {
             for (BattleContext unboost : unboosts) {
                 statChanges.compute(unboost.getId(), (key, value) -> (value == null ? 0 : value) - 1);
+            }
+        }
+
+        if (volatiles != null) {
+            for (BattleContext vol : volatiles) {
+                switch (vol.getId()) {
+                    case "focusenergy" -> statChanges.compute("crt",(key, value) -> (value == null ? 0 : value) + 2);
+                    case "dragoncheer" -> {
+                        boolean isDragon = pokemon.getEffectedPokemon().getPrimaryType() == ElementalTypes.DRAGON || pokemon.getEffectedPokemon().getSecondaryType() == ElementalTypes.DRAGON;
+                        statChanges.compute("crt",(key, value) -> (value == null ? 0 : value) + (isDragon ? 2 : 1));
+                    }
+                    default -> {}
+                }
             }
         }
 

--- a/common/src/main/java/com/github/yajatkaul/mega_showdown/client/battle/hud/BattleHUD.java
+++ b/common/src/main/java/com/github/yajatkaul/mega_showdown/client/battle/hud/BattleHUD.java
@@ -33,7 +33,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
-public class BattleHud {
+public class BattleHUD {
     private static int prevTime = 0;
     private static final Map<UUID, BattlePokemonMemory> memory = new HashMap<>();
     private static final List<TeamPreviewWidget> teamPreviews = List.of(new TeamPreviewWidget(0, 0, true), new TeamPreviewWidget(0, 0, false));

--- a/common/src/main/java/com/github/yajatkaul/mega_showdown/client/battle/hud/BattleHUD.java
+++ b/common/src/main/java/com/github/yajatkaul/mega_showdown/client/battle/hud/BattleHUD.java
@@ -73,7 +73,7 @@ public class BattleHUD {
                         .findAny();
 
                 if (anyActor.isEmpty()) return; // This should not happen!
-                boolean isLeft = anyActor.get().getSide().equals(battle.getSide1());
+                boolean isLeft = battle.getSpectating() && anyActor.get().getSide().equals(battle.getSide2());
 
                 for (BattlePokemonState battlePokemonState : side.getPokemon()) {
                     BattlePokemonMemory pokemon = memory.get(battlePokemonState.uuid());

--- a/common/src/main/java/com/github/yajatkaul/mega_showdown/client/battle/hud/BattleHUD.java
+++ b/common/src/main/java/com/github/yajatkaul/mega_showdown/client/battle/hud/BattleHUD.java
@@ -333,8 +333,6 @@ public class BattleHUD {
                             case "special_attack" -> "spa";
                             case "special_defence" -> "spd";
                             case "speed" -> "spe";
-                            case "accuracy" -> "acc";
-                            case "evasion" -> "eva";
                             default -> key;
                         };
 

--- a/common/src/main/java/com/github/yajatkaul/mega_showdown/client/battle/hud/BattleHUD.java
+++ b/common/src/main/java/com/github/yajatkaul/mega_showdown/client/battle/hud/BattleHUD.java
@@ -24,9 +24,16 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.contents.TranslatableContents;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
 
-public class BattleHUD {
+public class BattleHud {
     private static int prevTime = 0;
     private static final Map<UUID, BattlePokemonMemory> memory = new HashMap<>();
     private static final List<TeamPreviewWidget> teamPreviews = List.of(new TeamPreviewWidget(0, 0, true), new TeamPreviewWidget(0, 0, false));
@@ -39,17 +46,17 @@ public class BattleHUD {
      * Arg1 is the user, Arg2 is the item
      */
     private static final Set<String> twoArgItemText = Set.of(
-            "cobblemon.battle.item.airballoon",
-            "cobblemon.battle.item.recycle",
-            "cobblemon.battle.item.harvest",
-            "cobblemon.battle.item.frisk",
-            "cobblemon.battle.item.bestow",
-            "cobblemon.battle.heal.leftovers",
-            "cobblemon.battle.heal.item",
-            "cobblemon.battle.damage.item"
+        "cobblemon.battle.item.airballoon",
+        "cobblemon.battle.item.recycle",
+        "cobblemon.battle.item.harvest",
+        "cobblemon.battle.item.frisk",
+        "cobblemon.battle.item.bestow",
+        "cobblemon.battle.heal.leftovers",
+        "cobblemon.battle.heal.item",
+        "cobblemon.battle.damage.item"
     );
 
-    public static void receivePacket(BattleStatePacketS2C packet, NetworkManager.PacketContext context) {
+    public static void receivePacket (BattleStatePacketS2C packet, NetworkManager.PacketContext context) {
         ClientBattle battle = CobblemonClient.INSTANCE.getBattle();
         if (CobblemonClient.INSTANCE.getBattle() == null || Minecraft.getInstance().player == null) return;
 
@@ -67,10 +74,10 @@ public class BattleHUD {
 
             packet.sides().forEach(side -> {
                 Optional<ClientBattleActor> anyActor = side.actors()
-                        .stream()
-                        .map(actor -> battle.getParticipatingActor(actor.uuid()))
-                        .filter(Objects::nonNull)
-                        .findAny();
+                    .stream()
+                    .map(actor -> battle.getParticipatingActor(actor.uuid()))
+                    .filter(Objects::nonNull)
+                    .findAny();
 
                 if (anyActor.isEmpty()) return; // This should not happen!
                 boolean isLeft = battle.getSpectating() && anyActor.get().getSide().equals(battle.getSide2());
@@ -86,7 +93,7 @@ public class BattleHUD {
         }
     }
 
-    public static void tickLocalBattleInfo() {
+    public static void tickLocalBattleInfo () {
         ClientBattle battle = CobblemonClient.INSTANCE.getBattle();
         if (CobblemonClient.INSTANCE.getBattle() == null || Minecraft.getInstance().player == null) return;
 
@@ -106,7 +113,8 @@ public class BattleHUD {
 
                 if (pokemon.getBattlePokemon().isHpFlat()) {
                     pokemonMemory.setHealthPercentage(pokemon.getBattlePokemon().getHpValue() / pokemon.getBattlePokemon().getMaxHp());
-                } else {
+                }
+                else {
                     pokemonMemory.setHealthPercentage(pokemon.getBattlePokemon().getHpValue());
                 }
 
@@ -138,22 +146,22 @@ public class BattleHUD {
 
                     if (pokemon.heldItem().isEmpty()) {
                         pokemonMemory.setItem("");
-                    } else if (pokemonMemory.getItem() == null) { // Too many weird edge cases involving items, the packets will always be correct so skip this if its already been done.
-                        pokemonMemory.setItem(pokemon.heldItem().getDisplayName());
+                    }
+                    else if (pokemonMemory.getItem() == null) { // Too many weird edge cases involving items, the packets will always be correct so skip this if its already been done.
+                        pokemonMemory.setItem(pokemon.heldItem().getDescriptionId());
                     }
 
                     PersistentStatusContainer status = pokemon.getStatus();
                     if (status == null) pokemonMemory.setStatus(null);
                     else pokemonMemory.setStatus(status.getStatus().getShowdownName());
 
-                    if (!teamPreviews.getFirst().hasPartyMember(pokemon.getUuid()))
-                        teamPreviews.getFirst().addPartyMember(new PokeballPreviewWidget(true, pokemonMemory));
+                    if (!teamPreviews.getFirst().hasPartyMember(pokemon.getUuid())) teamPreviews.getFirst().addPartyMember(new PokeballPreviewWidget(true, pokemonMemory));
                 }
             }
         }
     }
 
-    public static void messageCallback(List<Component> messages) {
+    public static void messageCallback (List<Component> messages) {
         ClientBattle battle = CobblemonClient.INSTANCE.getBattle();
         if (battle == null) return;
 
@@ -165,9 +173,9 @@ public class BattleHUD {
                     Object userArg = content.getArgs()[0];
                     Object moveArg = content.getArgs()[1];
                     if (userArg instanceof Component userText
-                            && userText.getContents() instanceof TranslatableContents
-                            && moveArg instanceof Component moveText
-                            && moveText.getContents() instanceof TranslatableContents argContent
+                        && userText.getContents() instanceof TranslatableContents
+                        && moveArg instanceof Component moveText
+                        && moveText.getContents() instanceof TranslatableContents argContent
                     ) {
                         OwnedPokemon owned = OwnedPokemon.fromTextArg(userArg);
                         ActiveClientBattlePokemon pokemon = getPokemon(battle, owned);
@@ -176,7 +184,8 @@ public class BattleHUD {
                         BattlePokemonMemory mem = memory.computeIfAbsent(pokemon.getBattlePokemon().getUuid(), BattlePokemonMemory::new);
                         mem.useMove(argContent.getKey().replace("cobblemon.move.", ""));
                     }
-                } else if (content.getKey().contains("cobblemon.battle.ability.") && content.getArgs().length >= 1) {
+                }
+                else if (content.getKey().contains("cobblemon.battle.ability.") && content.getArgs().length >= 1) {
                     OwnedPokemon owned = OwnedPokemon.fromTextArg(content.getArgs()[0]);
 
                     if (content.getKey().contains("generic") && content.getArgs().length >= 2) {
@@ -188,7 +197,8 @@ public class BattleHUD {
                                 mem.setAbility(content.getArgs()[1].toString());
                             }
                         }
-                    } else if (content.getKey().contains("trace") && content.getArgs().length >= 3) {
+                    }
+                    else if (content.getKey().contains("trace") && content.getArgs().length >= 3) {
                         ActiveClientBattlePokemon pokemon = getPokemon(battle, owned);
                         if (pokemon != null && pokemon.getBattlePokemon() != null) {
                             BattlePokemonMemory mem = memory.computeIfAbsent(pokemon.getBattlePokemon().getUuid(), BattlePokemonMemory::new);
@@ -202,33 +212,37 @@ public class BattleHUD {
                                 mem.setAbility(content.getArgs()[2].toString());
                             }
                         }
-                    } else if ((content.getKey().contains("replace") || content.getKey().contains("receiver")) && content.getArgs().length >= 2) {
+                    }
+                    else if ((content.getKey().contains("replace") || content.getKey().contains("receiver")) && content.getArgs().length >= 2) {
                         ActiveClientBattlePokemon pokemon = getPokemon(battle, owned);
                         if (pokemon != null && pokemon.getBattlePokemon() != null) {
                             BattlePokemonMemory mem = memory.computeIfAbsent(pokemon.getBattlePokemon().getUuid(), BattlePokemonMemory::new);
                             mem.setTempAbility(content.getArgs()[1].toString());
                         }
                     }
-                } else if (content.getKey().contains("cobblemon.battle.enditem.") && content.getArgs().length > 0) {
+                }
+                else if (content.getKey().contains("cobblemon.battle.enditem.") && content.getArgs().length > 0) {
                     OwnedPokemon owned = OwnedPokemon.fromTextArg(content.getArgs()[0]);
                     ActiveClientBattlePokemon pokemon = getPokemon(battle, owned);
                     if (pokemon != null && pokemon.getBattlePokemon() != null) {
                         BattlePokemonMemory mem = memory.computeIfAbsent(pokemon.getBattlePokemon().getUuid(), BattlePokemonMemory::new);
                         mem.setConsumedItem(true);
                     }
-                } else if (content.getKey().contains("cobblemon.battle.transform") && content.getArgs().length > 0) {
+                }
+                else if (content.getKey().contains("cobblemon.battle.transform") && content.getArgs().length > 0) {
                     OwnedPokemon owned = OwnedPokemon.fromTextArg(content.getArgs()[0]);
                     ActiveClientBattlePokemon pokemon = getPokemon(battle, owned);
                     if (pokemon != null && pokemon.getBattlePokemon() != null) {
                         BattlePokemonMemory mem = memory.computeIfAbsent(pokemon.getBattlePokemon().getUuid(), BattlePokemonMemory::new);
                         mem.setTransformed(true);
                     }
-                } else if (content.getKey().contains("cobblemon.battle.end.illusion")) { // I hate Zoroark, omg
+                }
+                else if (content.getKey().contains("cobblemon.battle.end.illusion")) { // I hate Zoroark, omg
                     int indexOfMoveOrEffectiveness = messagesThisTurn.size() - 2;
                     int indexOfMove = messagesThisTurn.size() - 3;
                     if (indexOfMoveOrEffectiveness >= 0
-                            && messagesThisTurn.get(indexOfMoveOrEffectiveness).getContents() instanceof TranslatableContents content2
-                            && content2.getKey().contains("cobblemon.battle.used_move_on")
+                        && messagesThisTurn.get(indexOfMoveOrEffectiveness).getContents() instanceof TranslatableContents content2
+                        && content2.getKey().contains("cobblemon.battle.used_move_on")
                     ) {
                         OwnedPokemon owned = OwnedPokemon.fromTextArg(content2.getArgs()[2]);
                         BattlePokemonMemory mem = getMemory(owned);
@@ -239,9 +253,10 @@ public class BattleHUD {
 
                             mem.clearIllusoryData();
                         }
-                    } else if (indexOfMove >= 0
-                            && messagesThisTurn.get(indexOfMove).getContents() instanceof TranslatableContents content2
-                            && content2.getKey().contains("cobblemon.battle.used_move_on")
+                    }
+                    else if (indexOfMove >= 0
+                        && messagesThisTurn.get(indexOfMove).getContents() instanceof TranslatableContents content2
+                        && content2.getKey().contains("cobblemon.battle.used_move_on")
                     ) {
                         OwnedPokemon owned = OwnedPokemon.fromTextArg(content2.getArgs()[2]);
                         BattlePokemonMemory mem = getMemory(owned);
@@ -252,37 +267,38 @@ public class BattleHUD {
 
                             mem.clearIllusoryData();
                         }
-                    } else {
+                    }
+                    else {
                         Optional<UUID> inactiveUUID = getAllActivePokemon(battle)
-                                .stream()
-                                .filter(p -> p.getBattlePokemon() != null)
-                                .map(p -> p.getBattlePokemon().getUuid())
-                                .filter(uuid -> pokemonAtTurnStart.stream().noneMatch(pokemon -> pokemon.equals(uuid)))
-                                .findAny();
+                            .stream()
+                            .filter(p -> p.getBattlePokemon() != null)
+                            .map(p -> p.getBattlePokemon().getUuid())
+                            .filter(uuid -> pokemonAtTurnStart.stream().noneMatch(pokemon -> pokemon.equals(uuid)))
+                            .findAny();
 
                         if (inactiveUUID.isPresent()) {
                             BattlePokemonMemory mem = memory.get(inactiveUUID.get());
                             mem.clearIllusoryData();
                         }
                     }
-                } else if (content.getKey().contains("cobblemon.battle.turn")) {
+                }
+                else if (content.getKey().contains("cobblemon.battle.turn")) {
                     List<ActiveClientBattlePokemon> current = getAllActivePokemon(battle);
                     List<UUID> removed = pokemonAtTurnStart
-                            .stream()
-                            .filter(uuid -> current.stream().noneMatch(pokemon -> pokemon.getBattlePokemon() != null && pokemon.getBattlePokemon().getUuid().equals(uuid)))
-                            .toList();
+                        .stream()
+                        .filter(uuid -> current.stream().noneMatch(pokemon -> pokemon.getBattlePokemon() != null && pokemon.getBattlePokemon().getUuid().equals(uuid)))
+                        .toList();
 
                     List<UUID> sentOut = current
-                            .stream()
-                            .filter(pokemon -> pokemon.getBattlePokemon() != null)
-                            .map(pokemon -> pokemon.getBattlePokemon().getUuid())
-                            .filter(uuid -> pokemonAtTurnStart.stream().noneMatch(uuid1 -> uuid1.equals(uuid)))
-                            .toList();
+                        .stream()
+                        .filter(pokemon -> pokemon.getBattlePokemon() != null)
+                        .map(pokemon -> pokemon.getBattlePokemon().getUuid())
+                        .filter(uuid -> pokemonAtTurnStart.stream().noneMatch(uuid1 -> uuid1.equals(uuid)))
+                        .toList();
 
                     pokemonAtTurnStart.clear();
                     for (ActiveClientBattlePokemon pokemon : current) {
-                        if (pokemon.getBattlePokemon() != null)
-                            pokemonAtTurnStart.add(pokemon.getBattlePokemon().getUuid());
+                        if (pokemon.getBattlePokemon() != null) pokemonAtTurnStart.add(pokemon.getBattlePokemon().getUuid());
                     }
 
                     for (UUID pokemon : sentOut) {
@@ -320,7 +336,8 @@ public class BattleHUD {
                         }
                     }
                     messagesThisTurn.clear();
-                } else if ((content.getKey().contains("cobblemon.battle.boost.") || content.getKey().contains("cobblemon.battle.unboost.")) && content.getArgs().length >= 2) {
+                }
+                else if ((content.getKey().contains("cobblemon.battle.boost.") || content.getKey().contains("cobblemon.battle.unboost.")) && content.getArgs().length >= 2) {
                     if (content.getArgs()[1] instanceof Component statText && statText.getContents() instanceof TranslatableContents statContent) {
                         OwnedPokemon pokemon = OwnedPokemon.fromTextArg(content.getArgs()[0]);
                         BattlePokemonMemory mem = getMemory(pokemon);
@@ -343,24 +360,35 @@ public class BattleHUD {
                         else if (content.getKey().contains("severe")) amount = 3;
 
                         if (amount > 0) {
-                            mem.getStatChanges().put(key, mem.getStatChanges().getOrDefault(key, 0) + amount * multiplier);
+                            mem.addStatChange(key, amount * multiplier);
                         }
                     }
-                } else if (content.getKey().contains("cobblemon.battle.clearallboost")) {
+                }
+                else if (content.getKey().contains("cobblemon.battle.start.focusenergy") && content.getArgs().length > 0) {
+                    OwnedPokemon pokemon = OwnedPokemon.fromTextArg(content.getArgs()[0]);
+                    BattlePokemonMemory mem = getMemory(pokemon);
+                    if (mem == null) continue;
+
+                    mem.addStatChange("crt", 2);
+                }
+                else if (content.getKey().contains("cobblemon.battle.clearallboost")) {
                     memory.values().forEach(mem -> mem.getStatChanges().clear());
-                } else if (content.getKey().contains("cobblemon.battle.clearallnegativeboost") && content.getArgs().length > 0) {
+                }
+                else if (content.getKey().contains("cobblemon.battle.clearallnegativeboost") && content.getArgs().length > 0) {
                     OwnedPokemon pokemon = OwnedPokemon.fromTextArg(content.getArgs()[0]);
                     BattlePokemonMemory mem = getMemory(pokemon);
                     if (mem != null) {
                         mem.getStatChanges().replaceAll((key, value) -> value < 0 ? 0 : value);
                     }
-                } else if (content.getKey().contains("cobblemon.battle.clearboost") && content.getArgs().length > 0) {
+                }
+                else if (content.getKey().contains("cobblemon.battle.clearboost") && content.getArgs().length > 0) {
                     OwnedPokemon pokemon = OwnedPokemon.fromTextArg(content.getArgs()[0]);
                     BattlePokemonMemory mem = getMemory(pokemon);
                     if (mem != null) {
                         mem.getStatChanges().clear();
                     }
-                } else if (content.getKey().contains("cobblemon.battle.setboost.") && content.getArgs().length > 0) {
+                }
+                else if (content.getKey().contains("cobblemon.battle.setboost.") && content.getArgs().length > 0) {
                     OwnedPokemon pokemon = OwnedPokemon.fromTextArg(content.getArgs()[0]);
                     BattlePokemonMemory mem = getMemory(pokemon);
                     if (mem == null) continue;
@@ -368,7 +396,8 @@ public class BattleHUD {
                     if (content.getKey().contains("bellydrum") || content.getKey().contains("angerpoint")) {
                         mem.getStatChanges().put("atk", 6);
                     }
-                } else { // There is nothing consistent for items
+                }
+                else { // There is nothing consistent for items
                     if (twoArgItemText.contains(content.getKey()) && content.getArgs().length >= 2) {
                         String item;
                         OwnedPokemon owned = OwnedPokemon.fromTextArg(content.getArgs()[0]);
@@ -376,24 +405,28 @@ public class BattleHUD {
                         if (content.getArgs()[1] instanceof Component itemText) {
                             if (itemText.getContents() instanceof TranslatableContents itemContent) {
                                 item = itemContent.getKey();
-                            } else {
+                            }
+                            else {
                                 item = itemText.getString();
                             }
-                        } else item = content.getArgs()[1].toString();
+                        }
+                        else item = content.getArgs()[1].toString();
 
                         ActiveClientBattlePokemon pokemon = getPokemon(battle, owned);
                         if (pokemon != null && pokemon.getBattlePokemon() != null) {
                             BattlePokemonMemory mem = memory.computeIfAbsent(pokemon.getBattlePokemon().getUuid(), BattlePokemonMemory::new);
                             mem.setItem(item);
                         }
-                    } else if (content.getKey().equalsIgnoreCase("cobblemon.battle.damage.rockyhelmet") && content.getArgs().length >= 2) {
+                    }
+                    else if (content.getKey().equalsIgnoreCase("cobblemon.battle.damage.rockyhelmet") && content.getArgs().length >= 2) {
                         OwnedPokemon owned = OwnedPokemon.fromTextArg(content.getArgs()[1]);
                         ActiveClientBattlePokemon pokemon = getPokemon(battle, owned);
                         if (pokemon != null && pokemon.getBattlePokemon() != null) {
                             BattlePokemonMemory mem = memory.computeIfAbsent(pokemon.getBattlePokemon().getUuid(), BattlePokemonMemory::new);
                             mem.setItem(CobblemonItems.ROCKY_HELMET);
                         }
-                    } else if (content.getKey().equalsIgnoreCase("cobblemon.battle.damage.lifeorb") && content.getArgs().length >= 1) {
+                    }
+                    else if (content.getKey().equalsIgnoreCase("cobblemon.battle.damage.lifeorb") && content.getArgs().length >= 1) {
                         OwnedPokemon owned = OwnedPokemon.fromTextArg(content.getArgs()[0]);
                         ActiveClientBattlePokemon pokemon = getPokemon(battle, owned);
                         if (pokemon != null && pokemon.getBattlePokemon() != null) {
@@ -406,7 +439,7 @@ public class BattleHUD {
         }
     }
 
-    public static void hudCallback(GuiGraphics context, DeltaTracker counter) {
+    public static void hudCallback (GuiGraphics context, DeltaTracker counter) {
         ClientBattle battle = CobblemonClient.INSTANCE.getBattle();
         if (battle == null) {
             memory.clear();
@@ -425,8 +458,8 @@ public class BattleHUD {
 
             int height = Minecraft.getInstance().getWindow().getGuiScaledHeight();
             int width = Minecraft.getInstance().getWindow().getGuiScaledWidth();
-            int mouseX = (int) (Minecraft.getInstance().mouseHandler.xpos() * width / Minecraft.getInstance().getWindow().getWidth());
-            int mouseY = (int) (Minecraft.getInstance().mouseHandler.ypos() * height / Minecraft.getInstance().getWindow().getHeight());
+            int mouseX = (int)(Minecraft.getInstance().mouseHandler.xpos() * width / Minecraft.getInstance().getWindow().getWidth());
+            int mouseY = (int)(Minecraft.getInstance().mouseHandler.ypos() * height / Minecraft.getInstance().getWindow().getHeight());
             float tickDelta = counter.getGameTimeDeltaPartialTick(true);
 
             for (TeamPreviewWidget widget : teamPreviews) {
@@ -436,7 +469,7 @@ public class BattleHUD {
         }
     }
 
-    public static void drawStatChanges(GuiGraphics context, ActiveClientBattlePokemon pokemon, boolean isLeft, int rank, boolean isCompact) {
+    public static void drawStatChanges (GuiGraphics context, ActiveClientBattlePokemon pokemon, boolean isLeft, int rank, boolean isCompact) {
         BattlePokemonMemory mem = getMemory(pokemon);
         if (!MegaShowdownConfig.showStatChanges || mem == null) return;
 
@@ -444,18 +477,18 @@ public class BattleHUD {
     }
 
     @Nullable
-    private static ActiveClientBattlePokemon getPokemon(ClientBattle battle, OwnedPokemon pokemon) {
+    private static ActiveClientBattlePokemon getPokemon (ClientBattle battle, OwnedPokemon pokemon) {
         return getPokemon(battle, pokemon.pokemon, pokemon.owner);
     }
 
     @Nullable
-    private static ActiveClientBattlePokemon getPokemon(ClientBattle battle, String name, String owner) {
+    private static ActiveClientBattlePokemon getPokemon (ClientBattle battle, String name, String owner) {
         for (ClientBattleSide side : battle.getSides()) {
             for (ActiveClientBattlePokemon pokemon : side.getActiveClientBattlePokemon()) {
                 if (pokemon.getBattlePokemon() == null) continue;
 
                 if (pokemon.getBattlePokemon().getDisplayName().getString().equals(name)
-                        && pokemon.getActor().getDisplayName().getString().equals(owner)
+                    && pokemon.getActor().getDisplayName().getString().equals(owner)
                 ) {
                     return pokemon;
                 }
@@ -464,7 +497,7 @@ public class BattleHUD {
         return null;
     }
 
-    private static List<ActiveClientBattlePokemon> getAllActivePokemon(ClientBattle battle) {
+    private static List<ActiveClientBattlePokemon> getAllActivePokemon (ClientBattle battle) {
         List<ActiveClientBattlePokemon> list = new ArrayList<>();
         for (ClientBattleSide side : battle.getSides()) {
             for (ActiveClientBattlePokemon pokemon : side.getActiveClientBattlePokemon()) {
@@ -477,7 +510,7 @@ public class BattleHUD {
     }
 
     @Nullable
-    private static BattlePokemonMemory getOrCreateMemory(@Nullable ActiveClientBattlePokemon pokemon) {
+    private static BattlePokemonMemory getOrCreateMemory (@Nullable ActiveClientBattlePokemon pokemon) {
         if (pokemon != null && pokemon.getBattlePokemon() != null) {
             return memory.computeIfAbsent(pokemon.getBattlePokemon().getUuid(), BattlePokemonMemory::new);
         }
@@ -485,7 +518,7 @@ public class BattleHUD {
     }
 
     @Nullable
-    private static BattlePokemonMemory getMemory(@Nullable ActiveClientBattlePokemon pokemon) {
+    private static BattlePokemonMemory getMemory (@Nullable ActiveClientBattlePokemon pokemon) {
         if (pokemon != null && pokemon.getBattlePokemon() != null) {
             return memory.get(pokemon.getBattlePokemon().getUuid());
         }
@@ -493,15 +526,15 @@ public class BattleHUD {
     }
 
     @Nullable
-    private static BattlePokemonMemory getMemory(OwnedPokemon pokemon) {
+    private static BattlePokemonMemory getMemory (OwnedPokemon pokemon) {
         for (BattlePokemonMemory mem : memory.values()) {
             if (pokemon.owner().equals(mem.getOwner()) && pokemon.pokemon().equals(mem.getName())) return mem;
         }
         return null;
     }
 
-    private record OwnedPokemon(String pokemon, String owner) {
-        private static OwnedPokemon fromTextArg(Object arg) {
+    private record OwnedPokemon (String pokemon, String owner) {
+        private static OwnedPokemon fromTextArg (Object arg) {
             String pokemon;
             String owner;
 
@@ -512,11 +545,13 @@ public class BattleHUD {
 
                     if (content.getArgs()[1] instanceof Component pokemonText) pokemon = pokemonText.getString();
                     else pokemon = content.getArgs()[1].toString();
-                } else {
+                }
+                else {
                     pokemon = text.getString();
                     owner = text.getString();
                 }
-            } else {
+            }
+            else {
                 pokemon = arg.toString();
                 owner = arg.toString();
             }

--- a/common/src/main/java/com/github/yajatkaul/mega_showdown/client/battle/hud/MovePreviewWidget.java
+++ b/common/src/main/java/com/github/yajatkaul/mega_showdown/client/battle/hud/MovePreviewWidget.java
@@ -12,7 +12,6 @@ import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.client.gui.narration.NarrationElementOutput;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
-import net.minecraft.network.chat.Style;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.CommonColors;
 
@@ -30,7 +29,7 @@ public class MovePreviewWidget extends AbstractWidget {
     }
 
     @Override
-    protected void renderWidget(GuiGraphics context, int mouseX, int mouseY, float delta) {
+    protected void renderWidget (GuiGraphics context, int mouseX, int mouseY, float delta) {
         this.realignToScreen();
         context.pose().pushPose();
         context.pose().translate(0, 0, 100);
@@ -40,7 +39,7 @@ public class MovePreviewWidget extends AbstractWidget {
         Component none = Component.literal("-");
         Component power = this.move.getPower() > 0 ? this.stabPower() : none;
         Component effectChance = this.move.getEffectChances().length == 0 ? Component.literal("-") : Component.literal(String.valueOf(this.move.getEffectChances()[0].intValue())).append("%");
-        Component accuracy = this.move.getAccuracy() > 0 ? Component.literal(String.valueOf((int) this.move.getAccuracy())).append("%") : none;
+        Component accuracy = this.move.getAccuracy() > 0 ? Component.literal(String.valueOf((int)this.move.getAccuracy())).append("%") : none;
 
         int powerWidth = TEXT_RENDERER.width(power);
         int effectWidth = TEXT_RENDERER.width(effectChance);
@@ -50,13 +49,13 @@ public class MovePreviewWidget extends AbstractWidget {
         context.pose().pushPose();
         context.pose().scale(scale, scale, 1);
 
-        int leftTextStart = (int) ((this.getX() + 15) / scale);
+        int leftTextStart = (int)((this.getX() + 15) / scale);
         int leftNumberStart = leftTextStart + 104;
-        int rightTextStart = (int) ((this.getX() + 107.5) / scale);
+        int rightTextStart = (int)((this.getX() + 107.5) / scale);
         int rightNumberStart = rightTextStart + 106;
 
-        int row1Y = (int) ((this.getY() + 6.5) / scale);
-        int row2Y = (int) ((this.getY() + 18.5) / scale);
+        int row1Y = (int)((this.getY() + 6.5) / scale);
+        int row2Y = (int)((this.getY() + 18.5) / scale);
 
         context.drawString(TEXT_RENDERER, Component.translatable("cobblemon.ui.power"), leftTextStart, row1Y, CommonColors.WHITE, false);
         context.drawString(TEXT_RENDERER, power, rightNumberStart - powerWidth, row1Y, CommonColors.WHITE, false);
@@ -67,7 +66,7 @@ public class MovePreviewWidget extends AbstractWidget {
         context.drawString(TEXT_RENDERER, Component.translatable("cobblemon.ui.accuracy"), rightTextStart, row2Y, CommonColors.WHITE, false);
         context.drawString(TEXT_RENDERER, accuracy, rightNumberStart - accuracyWidth, row2Y, CommonColors.WHITE, false);
 
-        context.drawWordWrap(TEXT_RENDERER, this.move.getDescription(), (int) ((this.getX() + 6) / scale), (int) ((this.getY() + 35) / scale), (int) (182 / scale), CommonColors.WHITE);
+        context.drawWordWrap(TEXT_RENDERER, this.move.getDescription(), (int)((this.getX() + 6) / scale), (int)((this.getY() + 35) / scale), (int)(182 / scale), CommonColors.WHITE);
         context.pose().popPose();
 
         context.pose().popPose();
@@ -78,31 +77,31 @@ public class MovePreviewWidget extends AbstractWidget {
 
     }
 
-    private void realignToScreen() {
+    private void realignToScreen () {
         int screenHeight = Minecraft.getInstance().getWindow().getGuiScaledHeight();
 
         this.setX(TeamPreviewWidget.WIDTH + 2);
         this.setY(screenHeight - HEIGHT - 90);
     }
 
-    public void setSTAB(Pokemon pokemon, ElementalType type) {
+    public void setSTAB (Pokemon pokemon, ElementalType type) {
         if (pokemon.getPrimaryType().equals(type)) this.isSTAB = true;
         else this.isSTAB = pokemon.getSecondaryType() != null && pokemon.getSecondaryType().equals(type);
     }
 
-    private Component stabPower() {
+    private Component stabPower () {
         if (this.move.getPower() <= 1) { // Z-Moves have a power of 1
             return Component.literal("???");
         }
 
-        MutableComponent base = Component.literal(String.valueOf((int) this.move.getPower()));
+        int power = (int)this.move.getPower();
+        MutableComponent text = Component.literal(String.valueOf(power));
         if (this.isSTAB) {
-            int stabValue = (int) (this.move.getPower() * 1.5);
-            MutableComponent stabBonus = Component.literal(" (").append(String.valueOf(stabValue)).append(")");
-            stabBonus.setStyle(Style.EMPTY.withColor(ChatFormatting.YELLOW));
-            base.append(stabBonus);
+            int stabValue = (int)(this.move.getPower() * 1.5);
+            Component stabText = Component.literal(String.valueOf(stabValue)).withStyle(ChatFormatting.YELLOW);
+            text = Component.translatable("gui.battle.mega_showdown.move.power_with_stab", power, stabText);
         }
 
-        return base;
+        return text;
     }
 }

--- a/common/src/main/java/com/github/yajatkaul/mega_showdown/client/battle/hud/StatChangeRenderer.java
+++ b/common/src/main/java/com/github/yajatkaul/mega_showdown/client/battle/hud/StatChangeRenderer.java
@@ -34,9 +34,10 @@ public final class StatChangeRenderer {
         for (Map.Entry<String, Integer> statChange : memory.getStatChanges().entrySet()) {
             if (statChange.getValue() == 0) continue;
 
-            MutableComponent text = Component.literal(statChange.getKey().toUpperCase(Locale.ROOT));
-            if (statChange.getValue() > 0) text.append(" +" + statChange.getValue());
-            else text.append(" " + statChange.getValue());
+            Component stat = Component.translatableWithFallback("gui.battle.mega_showdown.stat." + statChange.getKey(), statChange.getKey().toLowerCase(Locale.ROOT));
+
+            String statString = statChange.getValue() > 0 ? "+" + statChange.getValue() : String.valueOf(statChange.getValue());
+            MutableComponent text = Component.translatable("gui.battle.mega_showdown.stat", stat, statString);
 
             text.setStyle(Style.EMPTY.withFont(CobblemonResources.INSTANCE.getDEFAULT_LARGE()).withBold(true));
 

--- a/common/src/main/java/com/github/yajatkaul/mega_showdown/client/battle/hud/StatChangeRenderer.java
+++ b/common/src/main/java/com/github/yajatkaul/mega_showdown/client/battle/hud/StatChangeRenderer.java
@@ -14,23 +14,20 @@ import java.util.Locale;
 import java.util.Map;
 
 public final class StatChangeRenderer {
-    private StatChangeRenderer() {
-    }
+    private StatChangeRenderer () {}
 
     private static final int TEXT_HEIGHT = 11;
     private static final Font TEXT_RENDERER = Minecraft.getInstance().font;
 
-    public static void render(GuiGraphics context, BattlePokemonMemory memory, boolean isLeft, int order, boolean isCompact) {
+    public static void render (GuiGraphics context, BattlePokemonMemory memory, boolean isLeft, int order, boolean isCompact) {
         int screenWidth = Minecraft.getInstance().getWindow().getGuiScaledWidth();
 
-        int x;
-        int y = isCompact ? BattleOverlay.VERTICAL_INSET + order * BattleOverlay.COMPACT_TILE_HEIGHT : BattleOverlay.VERTICAL_INSET + BattleOverlay.TILE_HEIGHT - 1;
+        int startingLeftX = isCompact ? BattleOverlay.HORIZONTAL_INSET + BattleOverlay.TILE_WIDTH - 5 - order * 4 : BattleOverlay.HORIZONTAL_INSET;
+        int startingRightX = isCompact ? screenWidth - BattleOverlay.HORIZONTAL_INSET - BattleOverlay.TILE_WIDTH + 4 + order * 4 : screenWidth - BattleOverlay.HORIZONTAL_INSET - 1;
+        int startingX = isLeft ? startingLeftX : startingRightX;
 
-        if (isLeft) {
-            x = isCompact ? BattleOverlay.HORIZONTAL_INSET + BattleOverlay.TILE_WIDTH - 5 - order * 4 : BattleOverlay.HORIZONTAL_INSET;
-        } else {
-            x = isCompact ? screenWidth - BattleOverlay.HORIZONTAL_INSET - BattleOverlay.TILE_WIDTH + 4 + order * 4 : screenWidth - BattleOverlay.HORIZONTAL_INSET - 1;
-        }
+        int x = startingX;
+        int y = isCompact ? BattleOverlay.VERTICAL_INSET + order * BattleOverlay.COMPACT_TILE_HEIGHT : BattleOverlay.VERTICAL_INSET + BattleOverlay.TILE_HEIGHT - 1;
 
         int iterations = 0;
 
@@ -45,20 +42,21 @@ public final class StatChangeRenderer {
 
             if (isLeft) {
                 x += renderBorderedText(context, x, y, text);
-            } else {
+            }
+            else {
                 int textWidth = TEXT_RENDERER.width(text);
                 x -= textWidth + 4;
                 renderBorderedText(context, x, y, text);
             }
 
             if (++iterations % 4 == 0) {
-                x = isLeft ? BattleOverlay.HORIZONTAL_INSET : screenWidth - BattleOverlay.HORIZONTAL_INSET - 1;
+                x = startingX;
                 y += TEXT_HEIGHT - 1;
             }
         }
     }
 
-    private static int renderBorderedText(GuiGraphics context, int x, int y, Component text) {
+    private static int renderBorderedText (GuiGraphics context, int x, int y, Component text) {
         int textWidth = TEXT_RENDERER.width(text) + 5;
         context.fill(x, y, x + textWidth, y + TEXT_HEIGHT, 0xFF8D8D8D);
         context.fill(x + 2, y + 2, x + textWidth - 2, y + TEXT_HEIGHT - 2, 0xFF676767);

--- a/common/src/main/java/com/github/yajatkaul/mega_showdown/client/battle/storage/BattlePokemonMemory.java
+++ b/common/src/main/java/com/github/yajatkaul/mega_showdown/client/battle/storage/BattlePokemonMemory.java
@@ -28,7 +28,15 @@ import net.minecraft.util.Mth;
 import org.joml.Quaternionf;
 import org.joml.Vector3f;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
 
 public class BattlePokemonMemory {
     public static final int PANEL_WIDTH = 150;
@@ -60,18 +68,18 @@ public class BattlePokemonMemory {
         this.uuid = uuid;
     }
 
-    public UUID getUuid() {
+    public UUID getUuid () {
         return this.uuid;
     }
 
-    public void setState(BattlePokemonState state) {
+    public void setState (BattlePokemonState state) {
         if (state.moves().isPresent()) {
             state.moves().get()
-                    .stream()
-                    .map(Moves::getByName)
-                    .filter(Objects::nonNull)
-                    .map(template -> template.create(template.getMaxPp(), 3))
-                    .forEach(this::addMove);
+                .stream()
+                .map(Moves::getByName)
+                .filter(Objects::nonNull)
+                .map(template -> template.create(template.getMaxPp(), 3))
+                .forEach(this::addMove);
         }
         this.healthPercentage = state.healthPercentage();
         this.status = state.status().orElse(null);
@@ -85,35 +93,35 @@ public class BattlePokemonMemory {
         this.statChanges.putAll(state.statChanges());
     }
 
-    public void setRenderablePokemon(RenderablePokemon renderablePokemon) {
+    public void setRenderablePokemon (RenderablePokemon renderablePokemon) {
         this.renderablePokemon = renderablePokemon;
     }
 
-    public boolean isActive() {
+    public boolean isActive () {
         return this.active;
     }
 
-    public void setActive(boolean active) {
+    public void setActive (boolean active) {
         this.active = active;
     }
 
-    public String getName() {
+    public String getName () {
         return this.name;
     }
 
-    public void setName(String name) {
+    public void setName (String name) {
         this.name = name;
     }
 
-    public String getOwner() {
+    public String getOwner () {
         return this.owner;
     }
 
-    public void setOwner(String owner) {
+    public void setOwner (String owner) {
         this.owner = owner;
     }
 
-    public void setMoves(MoveSet moves) {
+    public void setMoves (MoveSet moves) {
         this.knownMoves.clear();
         moves.forEach(move -> this.knownMoves.add(new Illusory<>(true, move)));
         while (this.knownMoves.size() < 4) {
@@ -121,13 +129,14 @@ public class BattlePokemonMemory {
         }
     }
 
-    public void addMove(Move move) {
+    public void addMove (Move move) {
         if (this.knownMoves.stream().map(Illusory::getData).anyMatch(template -> template.getName().equalsIgnoreCase(move.getName())))
             return;
 
         if (this.knownMoves.size() < 4) {
             this.knownMoves.add(new Illusory<>(this.illusionBroken, move));
-        } else {
+        }
+        else {
             Optional<Illusory<Move>> toRemove = this.knownMoves.stream().filter(Illusory::canBeCleared).findFirst();
             if (toRemove.isEmpty()) {
                 toRemove = this.knownMoves.stream().filter(iMove -> !iMove.isConfirmed()).findFirst();
@@ -140,23 +149,25 @@ public class BattlePokemonMemory {
         }
     }
 
-    public void useMove(String move) {
+    public void useMove (String move) {
         if (this.lastMove != null && SKIP_MOVE_MEMORY.contains(this.lastMove)) {
             this.lastMove = move;
             return;
-        } else if (this.transformed) {
+        }
+        else if (this.transformed) {
             return;
         }
         this.lastMove = move;
 
         Optional<Illusory<Move>> existing = this.knownMoves.stream()
-                .filter(move1 -> move1.getData().getName().equalsIgnoreCase(move))
-                .findAny();
+            .filter(move1 -> move1.getData().getName().equalsIgnoreCase(move))
+            .findAny();
 
         if (existing.isPresent()) {
             existing.get().getData().setCurrentPp(existing.get().getData().getCurrentPp() - 1);
             if (this.illusionBroken) existing.get().confirmed = true;
-        } else {
+        }
+        else {
             MoveTemplate template = Moves.getByNameOrDummy(move);
             Move realMove = template.create(template.getMaxPp(), 3);
             realMove.setCurrentPp(realMove.getCurrentPp() - 1);
@@ -164,86 +175,86 @@ public class BattlePokemonMemory {
         }
     }
 
-    public Move getMove(int index) {
+    public Move getMove (int index) {
         if (index >= this.knownMoves.size()) return MoveTemplate.Companion.dummy("unknown").create();
         return this.knownMoves.get(index).getData();
     }
 
-    public Map<String, Integer> getStatChanges() {
+    public Map<String, Integer> getStatChanges () {
         return this.statChanges;
     }
 
-    public double lerpHealthPercentage(double tickDelta) {
+    public void addStatChange (String key, int amount) {
+        this.statChanges.put(key, this.statChanges.getOrDefault(key, 0) + amount);
+    }
+
+    public double lerpHealthPercentage (double tickDelta) {
         return Mth.lerp(tickDelta, this.prevHealthPercentage, this.healthPercentage);
     }
 
-    public double getHealthPercentage() {
+    public double getHealthPercentage () {
         return this.healthPercentage;
     }
 
-    public void setHealthPercentage(double healthPercentage) {
+    public void setHealthPercentage (double healthPercentage) {
         this.prevHealthPercentage = this.healthPercentage;
         this.healthPercentage = Math.clamp(healthPercentage, 0, 1);
     }
 
-    public boolean isAlive() {
+    public boolean isAlive () {
         return this.healthPercentage > 0;
     }
 
-    public void setStatus(String status) {
+    public void setStatus (String status) {
         this.status = status;
     }
 
-    public boolean hasStatus() {
+    public boolean hasStatus () {
         return this.status != null;
     }
 
-    public String getItem() {
+    public String getItem () {
         return this.item == null ? null : this.item.getData();
     }
 
-    public void setItem(String item) {
+    public void setItem (String item) {
         this.item = new Illusory<>(this.illusionBroken, item);
     }
 
-    public void setItem(Component item) {
-        this.item = new Illusory<>(this.illusionBroken, item.getString());
-    }
-
-    public void setItem(CobblemonItem item) {
+    public void setItem (CobblemonItem item) {
         this.item = new Illusory<>(this.illusionBroken, item.getDescriptionId());
     }
 
-    public void setConsumedItem(boolean consumedItem) {
+    public void setConsumedItem (boolean consumedItem) {
         this.consumedItem = consumedItem;
     }
 
-    public String getAbility() {
+    public String getAbility () {
         return this.ability;
     }
 
-    public void setAbility(String ability) {
+    public void setAbility (String ability) {
         this.ability = ability;
     }
 
-    public void setTempAbility(String tempAbility) {
+    public void setTempAbility (String tempAbility) {
         this.tempAbility = tempAbility;
     }
 
-    public boolean isTransformed() {
+    public boolean isTransformed () {
         return this.transformed;
     }
 
-    public void setTransformed(boolean transformed) {
+    public void setTransformed (boolean transformed) {
         this.transformed = transformed;
     }
 
-    public void onSendOut() {
+    public void onSendOut () {
         this.illusionBroken = false;
         this.statChanges.clear();
     }
 
-    public void onRemovedFromField() {
+    public void onRemovedFromField () {
         if (this.item != null) this.item.markOld();
         this.knownMoves.forEach(Illusory::markOld);
         this.tempAbility = null;
@@ -251,12 +262,12 @@ public class BattlePokemonMemory {
         this.statChanges.clear();
     }
 
-    public void clearIllusoryData() {
+    public void clearIllusoryData () {
         this.knownMoves.removeIf(Illusory::canBeCleared);
         if (this.item != null && this.item.canBeCleared()) this.item = null;
     }
 
-    public void confirmNoIllusion() {
+    public void confirmNoIllusion () {
         this.illusionBroken = true;
         for (Illusory<Move> move : this.knownMoves) {
             if (move.isNew()) move.confirmed = true;
@@ -264,7 +275,7 @@ public class BattlePokemonMemory {
         if (this.item != null) this.item.confirmed = true;
     }
 
-    public void transferIllusoryDataTo(BattlePokemonMemory other) {
+    public void transferIllusoryDataTo (BattlePokemonMemory other) {
         for (Illusory<Move> move : this.knownMoves) {
             if (move.canBeCleared()) other.useMove(move.getData().getName());
         }
@@ -276,24 +287,23 @@ public class BattlePokemonMemory {
         other.confirmNoIllusion();
     }
 
-    public void render(GuiGraphics context, int x, int y, float tickDelta, boolean isLeft) {
+    public void render (GuiGraphics context, int x, int y, float tickDelta, boolean isLeft) {
         // All Text
         {
             context.pose().pushPose();
             context.pose().translate(0, 0, 100);
 
             Component species;
-            if (this.renderablePokemon != null)
-                species = Component.translatable("cobblemon.species." + this.renderablePokemon.getSpecies().resourceIdentifier.getPath() + ".name");
+            if (this.renderablePokemon != null) species = Component.translatable("cobblemon.species." + this.renderablePokemon.getSpecies().resourceIdentifier.getPath() + ".name");
             else species = Component.translatable("gui.battle.mega_showdown.field.unknown");
 
             context.drawString(
-                    Minecraft.getInstance().font,
-                    species,
-                    x + 30,
-                    y + 4,
-                    CommonColors.WHITE,
-                    true
+                Minecraft.getInstance().font,
+                species,
+                x + 30,
+                y + 4,
+                CommonColors.WHITE,
+                true
             );
             this.renderForm(context, x, y);
             this.renderItem(context, x, y);
@@ -310,17 +320,17 @@ public class BattlePokemonMemory {
             context.pose().translate(x + 15, y - 5, 0);
             if (this.renderablePokemon != null) {
                 PokemonGuiUtilsKt.drawProfilePokemon(
-                        this.renderablePokemon,
-                        context.pose(),
-                        QuaternionUtilsKt.fromEulerXYZDegrees(new Quaternionf(), new Vector3f(13f, isLeft ? -35f : 35f, 0f)),
-                        PoseType.PROFILE,
-                        new FloatingState(),
-                        tickDelta,
-                        16f,
-                        true,
-                        false,
-                        1f, 1f, 1f, 1f,
-                        0f, 0f
+                    this.renderablePokemon,
+                    context.pose(),
+                    QuaternionUtilsKt.fromEulerXYZDegrees(new Quaternionf(), new Vector3f(13f, isLeft ? -35f : 35f, 0f)),
+                    PoseType.PROFILE,
+                    new FloatingState(),
+                    tickDelta,
+                    16f,
+                    true,
+                    false,
+                    1f, 1f, 1f, 1f,
+                    0f, 0f
                 );
             }
             context.disableScissor();
@@ -334,86 +344,86 @@ public class BattlePokemonMemory {
             final float scale = 1.4f;
             context.pose().scale(scale, scale, 1);
             new TypeIcon(
-                    (x + 16) / scale, (y + 30) / scale,
-                    this.renderablePokemon.getForm().getPrimaryType(),
-                    this.renderablePokemon.getForm().getSecondaryType(),
-                    true,
-                    true,
-                    7f,
-                    3.5f,
-                    1f
+                (x + 16) / scale, (y + 30) / scale,
+                this.renderablePokemon.getForm().getPrimaryType(),
+                this.renderablePokemon.getForm().getSecondaryType(),
+                true,
+                true,
+                7f,
+                3.5f,
+                1f
             ).render(context);
             context.pose().popPose();
         }
     }
 
-    private MutableComponent getMoveName(Move template) {
-        if (template.getName().equalsIgnoreCase("unknown"))
-            return Component.translatable("gui.battle.mega_showdown.field.unknown");
-        if (template.getName().equalsIgnoreCase("empty"))
-            return Component.translatable("gui.battle.mega_showdown.field.empty");
+    private MutableComponent getMoveName (Move template) {
+        if (template.getName().equalsIgnoreCase("unknown")) return Component.translatable("gui.battle.mega_showdown.field.unknown");
+        if (template.getName().equalsIgnoreCase("empty")) return Component.translatable("gui.battle.mega_showdown.field.empty");
         return Component.translatableWithFallback("cobblemon.move." + template.getName(), template.getName());
     }
 
-    private MutableComponent getMovePP(Move move) {
+    private MutableComponent getMovePP (Move move) {
         if (move.getName().equalsIgnoreCase("unknown") || move.getName().equalsIgnoreCase("empty")) {
             return Component.translatable("gui.battle.mega_showdown.move.pp", "-", "-");
         }
         return Component.translatable("gui.battle.mega_showdown.move.pp", move.getCurrentPp(), move.getMaxPp());
     }
 
-    private void renderForm(GuiGraphics context, int x, int y) {
+    private void renderForm (GuiGraphics context, int x, int y) {
         RenderHelperKt.drawScaledText(
-                context,
-                null,
-                Component.translatable("gui.battle.mega_showdown.form"),
-                x + 86.5, y + 16.5,
-                0.5f,
-                1f,
-                Integer.MAX_VALUE,
-                CommonColors.LIGHTER_GRAY,
-                true,
-                false,
-                null, null
+            context,
+            null,
+            Component.translatable("gui.battle.mega_showdown.form"),
+            x + 86.5, y + 16.5,
+            0.5f,
+            1f,
+            Integer.MAX_VALUE,
+            CommonColors.LIGHTER_GRAY,
+            true,
+            false,
+            null, null
         );
 
         MutableComponent formName;
         if (this.renderablePokemon == null) {
             formName = Component.translatable("gui.battle.mega_showdown.field.unknown");
-        } else if (this.renderablePokemon.getForm().formOnlyShowdownId().equalsIgnoreCase("normal")) {
+        }
+        else if (this.renderablePokemon.getForm().formOnlyShowdownId().equalsIgnoreCase("normal")){
             formName = Component.translatable("gui.battle.mega_showdown.field.empty");
-        } else {
+        }
+        else {
             formName = Component.translatableWithFallback("cobblemon.ui.pokedex.info.form." + this.renderablePokemon.getSpecies().showdownId() + "-" + this.renderablePokemon.getForm().formOnlyShowdownId(), this.renderablePokemon.getForm().formOnlyShowdownId());
         }
 
         RenderHelperKt.drawScaledText(
-                context,
-                null,
-                formName,
-                x + 86.5, y + 23,
-                0.75f,
-                1f,
-                Integer.MAX_VALUE,
-                CommonColors.WHITE,
-                true,
-                true,
-                null, null
+            context,
+            null,
+            formName,
+            x + 86.5, y + 23,
+            0.75f,
+            1f,
+            Integer.MAX_VALUE,
+            CommonColors.WHITE,
+            true,
+            true,
+            null, null
         );
     }
 
-    private void renderItem(GuiGraphics context, int x, int y) {
+    private void renderItem (GuiGraphics context, int x, int y) {
         RenderHelperKt.drawScaledText(
-                context,
-                null,
-                Component.translatable("gui.battle.mega_showdown.item"),
-                x + 86.5, y + 30.5,
-                0.5f,
-                1f,
-                Integer.MAX_VALUE,
-                CommonColors.LIGHTER_GRAY,
-                true,
-                false,
-                null, null
+            context,
+            null,
+            Component.translatable("gui.battle.mega_showdown.item"),
+            x + 86.5, y + 30.5,
+            0.5f,
+            1f,
+            Integer.MAX_VALUE,
+            CommonColors.LIGHTER_GRAY,
+            true,
+            false,
+            null, null
         );
 
         MutableComponent item;
@@ -421,63 +431,67 @@ public class BattlePokemonMemory {
         else if (this.item != null) {
             if (this.item.getData().isEmpty()) {
                 item = Component.translatable("gui.battle.mega_showdown.field.empty");
-            } else {
+            }
+            else {
                 Language lang = Language.getInstance();
                 if (lang.has(this.item.getData())) item = Component.translatable(this.item.getData());
-                else if (lang.has("item.cobblemon." + this.item))
-                    item = Component.translatable("item.cobblemon." + this.item);
+                else if (lang.has("item.cobblemon." + this.item)) item = Component.translatable("item.cobblemon." + this.item);
                 else item = Component.literal(this.item.getData());
             }
-        } else item = Component.translatable("gui.battle.mega_showdown.field.unknown");
+        }
+        else item = Component.translatable("gui.battle.mega_showdown.field.unknown");
 
         RenderHelperKt.drawScaledText(
-                context,
-                null,
-                item,
-                x + 86.5, y + 36.5,
-                0.75f,
-                1f,
-                Integer.MAX_VALUE,
-                CommonColors.WHITE,
-                true,
-                true,
-                null, null
+            context,
+            null,
+            item,
+            x + 86.5, y + 36.5,
+            0.75f,
+            1f,
+            Integer.MAX_VALUE,
+            CommonColors.WHITE,
+            true,
+            true,
+            null, null
         );
     }
 
-    private void renderAbility(GuiGraphics context, int x, int y) {
+    private void renderAbility (GuiGraphics context, int x, int y) {
         RenderHelperKt.drawScaledText(
-                context,
-                null,
-                Component.translatable("gui.battle.mega_showdown.ability"),
-                x + 75, y + 44.5,
-                0.5f,
-                1f,
-                Integer.MAX_VALUE,
-                CommonColors.LIGHTER_GRAY,
-                true,
-                false,
-                null, null
+            context,
+            null,
+            Component.translatable("gui.battle.mega_showdown.ability"),
+            x + 75, y + 44.5,
+            0.5f,
+            1f,
+            Integer.MAX_VALUE,
+            CommonColors.LIGHTER_GRAY,
+            true,
+            false,
+            null, null
         );
 
         MutableComponent ability = null;
         if (this.ability != null) {
             if (this.tempAbility != null) {
                 ability = Component.translatable(
-                        "gui.battle.mega_showdown.ability.temp",
-                        Component.translatableWithFallback("cobblemon.ability." + this.ability, this.ability),
-                        Component.translatableWithFallback("cobblemon.ability." + this.tempAbility, this.tempAbility)
+                    "gui.battle.mega_showdown.ability.temp",
+                    Component.translatableWithFallback("cobblemon.ability." + this.ability, this.ability),
+                    Component.translatableWithFallback("cobblemon.ability." + this.tempAbility, this.tempAbility)
                 );
-            } else {
+            }
+            else {
                 ability = Component.translatableWithFallback("cobblemon.ability." + this.ability, this.ability);
             }
-        } else if (this.tempAbility != null) {
+        }
+        else if (this.tempAbility != null) {
             ability = Component.translatable(
-                    "gui.battle.mega_showdown.ability.temp",
-                    Component.translatable("gui.battle.mega_showdown.field.unknown"),
-                    Component.translatableWithFallback("cobblemon.ability." + this.tempAbility, this.tempAbility)
+                "gui.battle.mega_showdown.ability.temp",
+                Component.translatable("gui.battle.mega_showdown.field.unknown"),
+                Component.translatableWithFallback("cobblemon.ability." + this.tempAbility, this.tempAbility)
             );
-        } else if (this.renderablePokemon == null) {
+        }
+        else if (this.renderablePokemon == null) {
             ability = Component.translatable("gui.battle.mega_showdown.field.unknown");
         }
 
@@ -497,33 +511,33 @@ public class BattlePokemonMemory {
         float scale = Minecraft.getInstance().font.width(ability) > 139 ? 0.5f : 0.75f;
 
         RenderHelperKt.drawScaledText(
-                context,
-                null,
-                ability,
-                x + 75, y + 51,
-                scale,
-                1f,
-                Integer.MAX_VALUE,
-                CommonColors.WHITE,
-                true,
-                true,
-                null, null
+            context,
+            null,
+            ability,
+            x + 75, y + 51,
+            scale,
+            1f,
+            Integer.MAX_VALUE,
+            CommonColors.WHITE,
+            true,
+            true,
+            null, null
         );
     }
 
-    private void renderMoves(GuiGraphics context, int x, int y) {
+    private void renderMoves (GuiGraphics context, int x, int y) {
         RenderHelperKt.drawScaledText(
-                context,
-                null,
-                Component.translatable("gui.battle.mega_showdown.moves"),
-                x + 75, y + 64.5,
-                0.5f,
-                1f,
-                Integer.MAX_VALUE,
-                CommonColors.LIGHTER_GRAY,
-                true,
-                false,
-                null, null
+            context,
+            null,
+            Component.translatable("gui.battle.mega_showdown.moves"),
+            x + 75, y + 64.5,
+            0.5f,
+            1f,
+            Integer.MAX_VALUE,
+            CommonColors.LIGHTER_GRAY,
+            true,
+            false,
+            null, null
         );
 
         this.renderMove(context, this.getMove(0), x + 39.5, y + 70.5);
@@ -532,38 +546,38 @@ public class BattlePokemonMemory {
         this.renderMove(context, this.getMove(3), x + 110.5, y + 86.5);
     }
 
-    private void renderMove(GuiGraphics context, Move move, double x, double y) {
+    private void renderMove (GuiGraphics context, Move move, double x, double y) {
         Font textRenderer = Minecraft.getInstance().font;
 
         MutableComponent moveName = this.getMoveName(move);
         float scale1 = textRenderer.width(moveName) > 68 ? 0.5f : 0.75f;
         RenderHelperKt.drawScaledText(
-                context,
-                null,
-                moveName,
-                x, y,
-                scale1,
-                1f,
-                Integer.MAX_VALUE,
-                CommonColors.WHITE,
-                true,
-                true,
-                null, null
+            context,
+            null,
+            moveName,
+            x, y,
+            scale1,
+            1f,
+            Integer.MAX_VALUE,
+            CommonColors.WHITE,
+            true,
+            true,
+            null, null
         );
 
         MutableComponent ppCount = this.getMovePP(move);
         RenderHelperKt.drawScaledText(
-                context,
-                null,
-                ppCount,
-                x, y + 7,
-                0.5f,
-                1f,
-                Integer.MAX_VALUE,
-                CommonColors.WHITE,
-                true,
-                true,
-                null, null
+            context,
+            null,
+            ppCount,
+            x, y + 7,
+            0.5f,
+            1f,
+            Integer.MAX_VALUE,
+            CommonColors.WHITE,
+            true,
+            true,
+            null, null
         );
     }
 
@@ -572,29 +586,29 @@ public class BattlePokemonMemory {
         private boolean old;
         private final T data;
 
-        private Illusory(boolean confirmed, T data) {
+        private Illusory (boolean confirmed, T data) {
             this.confirmed = confirmed;
             this.data = data;
             this.old = false;
         }
 
-        private boolean isConfirmed() {
+        private boolean isConfirmed () {
             return this.confirmed;
         }
 
-        private boolean isNew() {
+        private boolean isNew () {
             return !this.old;
         }
 
-        private void markOld() {
+        private void markOld () {
             this.old = true;
         }
 
-        private boolean canBeCleared() {
+        private boolean canBeCleared () {
             return !this.old && !this.confirmed;
         }
 
-        private T getData() {
+        private T getData () {
             return this.data;
         }
     }

--- a/common/src/main/resources/assets/mega_showdown/lang/en_us.json
+++ b/common/src/main/resources/assets/mega_showdown/lang/en_us.json
@@ -662,5 +662,15 @@
   "gui.battle.mega_showdown.form": "Form",
   "gui.battle.mega_showdown.item": "Item",
   "gui.battle.mega_showdown.move.pp": "%1$s / %2$s",
-  "gui.battle.mega_showdown.moves": "Moves"
+  "gui.battle.mega_showdown.moves": "Moves",
+  "gui.battle.mega_showdown.stat": "%1$s %2$s",
+  "gui.battle.mega_showdown.stat.atk": "ATK",
+  "gui.battle.mega_showdown.stat.def": "DEF",
+  "gui.battle.mega_showdown.stat.spa": "SPA",
+  "gui.battle.mega_showdown.stat.spd": "SPD",
+  "gui.battle.mega_showdown.stat.spe": "SPE",
+  "gui.battle.mega_showdown.stat.accuracy": "ACC",
+  "gui.battle.mega_showdown.stat.evasion": "EVA",
+  "gui.battle.mega_showdown.stat.crt": "CRT",
+  "gui.battle.mega_showdown.move.power_with_stab": "%1$s §e(%2$s§e)"
 }


### PR DESCRIPTION
- Fixed the sides swapping when spectating a battle.
- Added crit chance to stat changes.
  - Specifically for "getting pumped" and Dragon Cheer.
    - Most crit boosts count as "getting pumped".
- Stat change display now uses translation keys.
- Fixed stat change display using the wrong X value for new lines when in double battles.