### PR TITLE
Fixed Gmax Charizard T-posing in Pokédex

### DIFF
--- a/common/src/main/resources/assets/cobblemon/bedrock/pokemon/posers/0006_charizard/charizard_gigantamax.json
+++ b/common/src/main/resources/assets/cobblemon/bedrock/pokemon/posers/0006_charizard/charizard_gigantamax.json
@@ -1,87 +1,33 @@
 {
   "portraitScale": 2.1,
-  "portraitTranslation": [
-    -1.0,
-    3.05,
-    0
-  ],
+  "portraitTranslation": [-1.0, 3.05, 0],
   "profileScale": 0.51,
-  "profileTranslation": [
-    0.05,
-    0.99,
-    -10
-  ],
+  "profileTranslation": [0.05, 0.99, -10],
   "rootBone": "charizard_gigantamax",
   "poses": {
     "portrait": {
-      "poseTypes": [
-        "PORTRAIT",
-        "PROFILE"
-      ],
-      "isBattle": false,
-      "isTouchingWater": false,
+      "poseTypes": ["PORTRAIT", "PROFILE"],
       "animations": [
         "q.look('head_ai')",
         "q.bedrock('charizard_gigantamax', 'battle_idle')"
       ],
-      "quirks": [
-        "q.bedrock_quirk('charizard_gigantamax', 'blink')"
-      ]
-    },
-    "battle-standing": {
-      "poseTypes": [
-        "STAND"
-      ],
-      "isBattle": true,
-      "isTouchingWater": false,
-      "animations": [
-        "q.look('head_ai')",
-        "q.bedrock('charizard_gigantamax', 'battle_idle')"
-      ],
-      "quirks": [
-        "q.bedrock_quirk('charizard_gigantamax', 'blink')"
-      ]
-    },
-    "battle-flying": {
-      "poseTypes": [
-        "HOVER"
-      ],
-      "isBattle": true,
-      "animations": [
-        "q.look('head_ai')",
-        "q.bedrock('charizard_gigantamax', 'air_idle')"
-      ],
-      "quirks": [
-        "q.bedrock_quirk('charizard_gigantamax', 'blink')"
-      ]
+      "quirks": ["q.bedrock_quirk('charizard_gigantamax', 'blink')"]
     },
     "standing": {
-      "poseTypes": [
-        "STAND",
-        "NONE"
-      ],
-      "isBattle": false,
-      "isTouchingWater": false,
+      "poseTypes": ["STAND", "NONE"],
       "animations": [
         "q.look('head_ai')",
-        "q.bedrock('charizard_gigantamax', 'ground_idle')"
+        "q.bedrock('charizard_gigantamax', 'battle_idle')"
       ],
-      "quirks": [
-        "q.bedrock_quirk('charizard_gigantamax', 'blink')"
-      ]
+      "quirks": ["q.bedrock_quirk('charizard_gigantamax', 'blink')"]
     },
     "hover": {
-      "poseTypes": [
-        "HOVER"
-      ],
-      "isBattle": false,
+      "poseTypes": ["HOVER"],
       "animations": [
         "q.look('head_ai')",
         "q.bedrock('charizard_gigantamax', 'air_idle')"
       ],
-      "quirks": [
-        "q.bedrock_quirk('charizard_gigantamax', 'blink')"
-      ]
+      "quirks": ["q.bedrock_quirk('charizard_gigantamax', 'blink')"]
     }
   }
 }


### PR DESCRIPTION
Due to it having a ground_idle listed in the poser, it defaulted to a t pose _(since it doesn't have a ground idle)_. Fixed that by removing the battle-standing poseType and making the standing with battle_idle its default. Also did some general formatting because of OCD idk.
## Before:
<img width="630" height="699" alt="image" src="https://github.com/user-attachments/assets/6266d187-021a-4de1-9b7e-76422faaaa22" />

## After:
<img width="591" height="678" alt="image" src="https://github.com/user-attachments/assets/a4e46382-e900-4412-914c-96fd5bd20703" />
